### PR TITLE
Checking user active flag before signing in.

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -2,8 +2,9 @@ package api
 
 // User holds the user data retrieved from the User API.
 type User struct {
-	ID            string
-	Email         string
-	Organizations []string
-	Roles         []string
+	ID            string   `json:"id"`
+	Email         string   `json:"email,omitempty"`
+	Organizations []string `json:"organizations,omitempty"`
+	Roles         []string `json:"roles,omitempty"`
+	Active        bool     `json:"active"`
 }

--- a/api/user.go
+++ b/api/user.go
@@ -114,6 +114,13 @@ func (userAPI *UserAPIClient) FindUser(email, password string) (*User, error) {
 	if ok {
 		user.Organizations = toStringArr(organizations)
 	}
+	if active, ok := (*userResp)["active"]; ok {
+		if active != nil {
+			if _, ok := active.(bool); ok {
+				user.Active = active.(bool)
+			}
+		}
+	}
 	return &user, nil
 }
 

--- a/signin.go
+++ b/signin.go
@@ -58,6 +58,11 @@ func (c *SigninController) Signin(ctx *app.SigninJWTContext) error {
 	if user == nil {
 		return ctx.BadRequest(goa.ErrBadRequest("invalid-credentials"))
 	}
+
+	if !user.Active {
+		return ctx.BadRequest(goa.ErrBadRequest("account-not-activated"))
+	}
+
 	key, err := c.KeyStore.GetPrivateKey()
 	if err != nil {
 		return ctx.InternalServerError(goa.ErrInternal(err))

--- a/signin_test.go
+++ b/signin_test.go
@@ -75,6 +75,7 @@ func TestSigninJWTCreated(t *testing.T) {
 				ID:            "000000000001",
 				Organizations: []string{"org1", "org2"},
 				Roles:         []string{"user"},
+				Active:        true,
 			}, nil
 		},
 	}, NewMockKeyStore(), config)


### PR DESCRIPTION
User.Active flag was not checked before issuing JWT (on signin). It is checked now and Bad Request (400) is returned of the user account is not active.